### PR TITLE
[FIX] revert DATA_DIR to MEDIA_ROOT

### DIFF
--- a/front/.env.template
+++ b/front/.env.template
@@ -29,7 +29,7 @@ ADMIN_NAME=admin
 ADMIN_EMAIL=admin@mail.com
 
 # absolute path to the data folder (for Docker => /data)
-DATA_DIR=/path/to/data
+MEDIA_ROOT=/path/to/data
 
 # must be same as port defined in spiped.service on prod server (prod => https://aikon-api.enpc.fr/)
 PROD_API_URL=http://localhost:5001

--- a/front/datasets/models.py
+++ b/front/datasets/models.py
@@ -47,7 +47,7 @@ class AbstractDataset(models.Model):
 
     @property
     def full_path(self) -> Path:
-        return Path(settings.DATA_DIR) / "datasets" / f"{self.id}"
+        return Path(settings.MEDIA_ROOT) / "datasets" / f"{self.id}"
 
     django_app_name = "datasets"  # must match INSTALLED_APPS and datasets.url.app_name
 
@@ -71,7 +71,7 @@ class Document:
         self.path = (
             Path(path)
             if path is not None
-            else Path(settings.DATA_DIR) / "documents" / self.uid
+            else Path(settings.MEDIA_ROOT) / "documents" / self.uid
         )
         self._document_tree = None
 
@@ -224,7 +224,7 @@ class Image:
 
     @property
     def url(self):
-        return f"{settings.MEDIA_URL}{self.path.relative_to(settings.DATA_DIR)}"
+        return f"{settings.MEDIA_URL}{self.path.relative_to(settings.MEDIA_ROOT)}"
 
 
 class Dataset(AbstractDataset):
@@ -433,7 +433,7 @@ class Dataset(AbstractDataset):
             i: Index of the crop
             doc_uid: The uid of the document
         """
-        return f"{settings.MEDIA_URL}{self.get_path_for_crop(crop, i, doc_uid).relative_to(settings.DATA_DIR)}"
+        return f"{settings.MEDIA_URL}{self.get_path_for_crop(crop, i, doc_uid).relative_to(settings.MEDIA_ROOT)}"
 
     def get_paths_for_crops(self, crops: List[Dict]) -> List[Path]:
         """
@@ -678,7 +678,7 @@ class Dataset(AbstractDataset):
     def cleaned_metadata_url(self) -> str:
         path = self.cleaned_metadata_path
         if path:
-            return f"{settings.MEDIA_URL}{path.relative_to(Path(settings.DATA_DIR))}"
+            return f"{settings.MEDIA_URL}{path.relative_to(Path(settings.MEDIA_ROOT))}"
         return None
 
     def clean_metadata(self):

--- a/front/demowebsite/settings/base.py
+++ b/front/demowebsite/settings/base.py
@@ -87,7 +87,7 @@ STATIC_URL = "static/"
 STATIC_ROOT = BASE_DIR / "staticfiles"
 
 MEDIA_URL = "media/"
-DATA_DIR = Path(ENV("DATA_DIR", default=BASE_DIR / "media"))
+MEDIA_ROOT = Path(ENV("MEDIA_ROOT", default=BASE_DIR / "media"))
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 

--- a/front/demowebsite/urls.py
+++ b/front/demowebsite/urls.py
@@ -19,4 +19,4 @@ urlpatterns = [
 
 # Serve media files in development
 if settings.DEBUG:
-    urlpatterns += static(settings.MEDIA_URL, document_root=settings.DATA_DIR)
+    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/front/main.py
+++ b/front/main.py
@@ -1,6 +1,0 @@
-def main():
-    print("Hello from front!")
-
-
-if __name__ == "__main__":
-    main()

--- a/front/manage.py
+++ b/front/manage.py
@@ -9,12 +9,17 @@ def main():
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'demowebsite.settings')
     try:
         from django.core.management import execute_from_command_line
+        from django.conf import settings
     except ImportError as exc:
         raise ImportError(
             "Couldn't import Django. Are you sure it's installed and "
             "available on your PYTHONPATH environment variable? Did you "
             "forget to activate a virtual environment?"
         ) from exc
+
+    assert settings.MEDIA_ROOT, "In Django settings, MEDIA_ROOT must not be empty"
+    assert settings.MEDIA_URL, "In Django settings, MEDIA_URL must not be empty"
+    
     execute_from_command_line(sys.argv)
 
 

--- a/front/regions/models.py
+++ b/front/regions/models.py
@@ -146,7 +146,7 @@ class Regions(AbstractAPITaskOnDataset("regions")):
             for idx, crop in enumerate(crops):
                 crop_path = self.dataset.get_path_for_crop(crop, doc_uid=doc_uid, i=idx)
                 crop_url = settings.MEDIA_URL + str(
-                    crop_path.relative_to(settings.DATA_DIR)
+                    crop_path.relative_to(settings.MEDIA_ROOT)
                 )
                 relative = crop["relative"]
                 formatted_crops.append(

--- a/front/search/models.py
+++ b/front/search/models.py
@@ -57,7 +57,7 @@ class Index(models.Model):
 
     @property
     def index_path(self):
-        return Path(settings.DATA_DIR) / f"search/index-{self.id}.json"
+        return Path(settings.MEDIA_ROOT) / f"search/index-{self.id}.json"
 
     @property
     def index_url(self):

--- a/front/tasking/models.py
+++ b/front/tasking/models.py
@@ -121,7 +121,7 @@ def AbstractTask(task_prefix: str):
         @property
         def result_media_path(self) -> str:
             """
-            Path to the result folder, relative to DATA_DIR
+            Path to the result folder, relative to MEDIA_ROOT
             """
             return f"{self.task_media_path}/result"
 
@@ -130,14 +130,14 @@ def AbstractTask(task_prefix: str):
             """
             Full path to the result folder
             """
-            return Path(settings.DATA_DIR) / self.task_media_path
+            return Path(settings.MEDIA_ROOT) / self.task_media_path
 
         @property
         def result_full_path(self) -> Path:
             """
             Full path to the result folder
             """
-            return Path(settings.DATA_DIR) / self.result_media_path
+            return Path(settings.MEDIA_ROOT) / self.result_media_path
 
         @property
         def log_file_path(self) -> Path:
@@ -313,7 +313,7 @@ def AbstractTask(task_prefix: str):
             Returns a dict with the monitoring data
             """
             total_size = 0
-            for f in Path(settings.DATA_DIR).glob("**/*"):
+            for f in Path(settings.MEDIA_ROOT).glob("**/*"):
                 if f.is_file():
                     total_size += f.stat().st_size
             n_datasets = (


### PR DESCRIPTION
batch renaming MEDIA_ROOT to DATA_DIR caused errors because MEDIA_ROOT is a Django variable that must be defined.